### PR TITLE
feat: partial asdf version support

### DIFF
--- a/lib/misc_funcs.sh
+++ b/lib/misc_funcs.sh
@@ -70,8 +70,20 @@ function load_config() {
   # Source for default versions file from buildpack first
   source "${build_pack_path}/elixir_buildpack.config"
 
-  erlang_version=$(extract_asdf_version "erlang")
-  elixir_version=$(extract_asdf_version "elixir")
+  asdf_erlang_version=$(extract_asdf_version "erlang")
+  asdf_elixir_version=$(extract_asdf_version "elixir")
+  if [ -z "${asdf_erlang_version}" ] && [ -n "${asdf_elixir_version}" ]; then
+    output_line "WARNING: Elixir version found in .tool-versions, but no Erlang version found."
+    output_line "         The elixir version will not be used from .tool-versions."
+  fi
+  if [ -n "${asdf_erlang_version}" ] && [ -z "${asdf_elixir_version}" ]; then
+    output_line "WARNING: Erlang version found in .tool-versions, but no Elixir version found."
+    output_line "         The erlang version will not be used from .tool-versions."
+  fi
+  if [ -n "${asdf_erlang_version}" ] && [ -n "${asdf_elixir_version}" ]; then
+    elixir_version=${asdf_elixir_version}
+    erlang_version=${asdf_erlang_version}
+  fi
 
   if [ -f $custom_config_file ];
   then

--- a/test/load_config.sh
+++ b/test/load_config.sh
@@ -10,11 +10,15 @@ source $SCRIPT_DIR/../lib/misc_funcs.sh
 
 # reset function
 function reset_test() {
+  output_lines=()
   erlang_version=""
   elixir_version=""
   rm -f $build_path/elixir_buildpack.config $build_path/.tool-versions
 }
 
+output_line() {
+  output_lines+=("$1")
+}
 
 # TESTS
 ######################
@@ -29,15 +33,12 @@ suite "load_config"
 
 
 
-
   test "missing config file, but has asdf file, missing erlang version"
 
     echo "elixir 1.10.4" > $build_path/.tool-versions
 
     load_config > /dev/null
 
-    [ -z "$erlang_version" ]
-    [ "$elixir_version" == "v1.10.4" ]
     [ $failed == "true" ]
 
 
@@ -48,8 +49,6 @@ suite "load_config"
 
     load_config > /dev/null
 
-    [ "$erlang_version" == "25.2" ]
-    [ -z "$elixir_version" ]
     [ $failed == "true" ]
 
 
@@ -79,6 +78,36 @@ suite "load_config"
     [ "$erlang_version" == "25.2" ]
     [ "$elixir_version" == "v1.10.4" ]
     [ $failed == "false" ]
+
+
+
+  test "has config file, but asdf overwrites only elixir"
+
+    echo "elixir 1.18.3" > $build_path/.tool-versions
+    echo "elixir_version=1.18.2
+erlang_version=27.0" > $build_path/elixir_buildpack.config
+
+    load_config > /dev/null
+
+    echo "${output_lines[@]}" | grep -q "WARNING: Elixir version found in .tool-versions, but no Erlang version found."
+    [ $failed == "false" ]
+    [ "$erlang_version" == "27.0" ]
+    [ "$elixir_version" == "v1.18.2" ]
+
+
+
+  test "has config file, but asdf overwrites only erlang"
+
+    echo "erlang 27.0" > $build_path/.tool-versions
+    echo "elixir_version=1.18.3
+erlang_version=26.0" > $build_path/elixir_buildpack.config
+
+    load_config > /dev/null
+
+    echo "${output_lines[@]}" | grep -q "WARNING: Erlang version found in .tool-versions, but no Elixir version found."
+    [ $failed == "false" ]
+    [ "$erlang_version" == "26.0" ]
+    [ "$elixir_version" == "v1.18.3" ]
 
 
 


### PR DESCRIPTION
This PR adds a warning to the user if their ASDF file only has one of an elixir or erlang version.  The asdf file will not be used in this scenario.
