### PR TITLE
Add support for Scalingo stacks

### DIFF
--- a/lib/canonical_version.sh
+++ b/lib/canonical_version.sh
@@ -8,10 +8,10 @@ erlang_builds_url() {
     "heroku-22")
       erlang_builds_url="https://builds.hex.pm/builds/otp/ubuntu-22.04"
       ;;
-    "heroku-24")
+    "heroku-24"|"scalingo-24")
       erlang_builds_url="https://builds.hex.pm/builds/otp/ubuntu-24.04"
       ;;
-    "heroku-26")
+    "heroku-26"|"scalingo-26")
       erlang_builds_url="https://builds.hex.pm/builds/otp/ubuntu-26.04"
       ;;
     *)
@@ -38,12 +38,12 @@ fetch_erlang_versions() {
       url="https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt"
       curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}' > /tmp/otp_versions
       ;;
-    "heroku-24")
+    "heroku-24"|"scalingo-24")
       url="https://builds.hex.pm/builds/otp/ubuntu-24.04/builds.txt"
       curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}' > /tmp/otp_versions
       ;;
-    "heroku-26")
-      url="https://builds.hex.pm/builds/otp/ubuntu-24.04/builds.txt"
+    "heroku-26"|"scalingo-26")
+      url="https://builds.hex.pm/builds/otp/ubuntu-26.04/builds.txt"
       curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}' > /tmp/otp_versions
       ;;
     *)

--- a/test/erlang_funcs.sh
+++ b/test/erlang_funcs.sh
@@ -64,6 +64,19 @@ suite "erlang_builds_url"
 
     [ "$result" == "https://builds.hex.pm/builds/otp/ubuntu-26.04" ]
 
+  test "returns scalingo-24 URL"
+
+    STACK="scalingo-24"
+    result=$(erlang_builds_url)
+
+    [ "$result" == "https://builds.hex.pm/builds/otp/ubuntu-24.04" ]
+
+  test "returns scalingo-26 URL"
+
+    STACK="scalingo-26"
+    result=$(erlang_builds_url)
+
+    [ "$result" == "https://builds.hex.pm/builds/otp/ubuntu-26.04" ]
 
   test "returns cedar-14 URL for unknown stack"
 


### PR DESCRIPTION
This PR adds support for the scalingo-24 and scalingo-26 stacks.

It maps each Scalingo stack to the corresponding Ubuntu Erlang/OTP builds:

- scalingo-24 uses the Ubuntu 24.04 builds
- scalingo-26 uses the Ubuntu 26.04 builds

This allows the buildpack to fetch and validate compatible Erlang/OTP versions when running on Scalingo.